### PR TITLE
Install correct version of Truffle and fail early on errors. Fixes #4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - "5001:5001"
   rabbit:
     hostname: rabbit
-    image: rabbitmq:latest
+    image: rabbitmq:management
     environment:
       - RABBITMQ_DEFAULT_USER=gnosisdb
       - RABBITMQ_DEFAULT_PASS=gnosisdb
@@ -51,8 +51,7 @@ services:
       - testrpc
     depends_on:
       - db
-    working_dir: /gnosisdb/gnosisdb
-    command: sh ../run_django.sh
+    command: sh run_django.sh
     ports:
       - "8000:8000"
       - "27017"

--- a/docker/ManagementDockerfile
+++ b/docker/ManagementDockerfile
@@ -2,7 +2,6 @@ FROM node:wheezy
 RUN apt-get update && apt-get install -y git
 RUN git clone https://github.com/gnosis/gnosis-management.git
 RUN cd gnosis-management && git checkout development && git pull origin development && npm install && npm install truffle-contract
-RUN npm install -g truffle
 ADD gnosis_management_setup.sh /gnosis-management/gnosis_management_setup.sh
 ADD truffle.js /gnosis-management/node_modules/\@gnosis.pm/gnosis-core-contracts/truffle.js
 ADD node/create_market.js /gnosis-management

--- a/docker/gnosis_management_setup.sh
+++ b/docker/gnosis_management_setup.sh
@@ -1,11 +1,13 @@
 #!/bin/sh
+set -e
 sleep 10
 echo "[GnosisDevKit] Setting Management up..."
 cd node_modules/@gnosis.pm/gnosis-core-contracts/
 echo "[GnosisDevKit] Migrating contracts..."
-truffle migrate --network development
 # Copy all generated files to /gnosis-core-contracts and share them via Volume
 cp -r * /gnosis-core-contracts && cd /gnosis-core-contracts && npm install
+./node_modules/.bin/truffle migrate --network development
+cp -r ./build /gnosis-management/node_modules/@gnosis.pm/gnosis-core-contracts
 sleep 5
 cd /gnosis-management
 node create_market.js

--- a/docker/run_celery.sh
+++ b/docker/run_celery.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 sleep 5
 
 until psql -h "db" -U "postgres" -c '\l'; do

--- a/docker/run_django.sh
+++ b/docker/run_django.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 sleep 5
 cd gnosisdb
 echo "==> Migrating Django <=="

--- a/docker/run_docs.sh
+++ b/docker/run_docs.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 sleep 5
 echo "==> Starting documentation on http://localhost:8888 <=="
 cd docs && mkdocs serve --dev-addr=0.0.0.0:8888

--- a/docker/testrpc_setup.sh
+++ b/docker/testrpc_setup.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
+set -e
 echo "[GnosisDevKit] Running TestRPC..."
 testrpc --port 8545 --host 0.0.0.0 -d -l 40000000 --rpc


### PR DESCRIPTION
In short, here are issues I've encountered:
* Dockerfile for `gnosis-management` installed a wrong version of Truffle with a different solidity compiler (0.4.18 vs 0.4.15). Errors were easy to miss, 'cause shell scripts just ignored them
* If `db` container launches after Gnosis DB, worker schedule won't be created (errors are easy to miss too)
* If there are no celery workers - blockchain events will be ignored, and new markets won't appear at Gnosis Management